### PR TITLE
change put format to {"value": <data>} (from {"body": <data>})

### DIFF
--- a/iron_cache.py
+++ b/iron_cache.py
@@ -118,7 +118,7 @@ class IronCache:
                 (int, long)):
             value = json.dumps(value)
 
-        options["body"] = value
+        options["value"] = value
         body = json.dumps(options)
 
         cache = urllib.quote_plus(cache)


### PR DESCRIPTION
from 2013-10-28 the python client is not able to put value in cache.
data is still sent under the "body" attribute. should be "value" attribute
